### PR TITLE
Use Buffer.from instead of Buffer

### DIFF
--- a/test/libp2p.spec.js
+++ b/test/libp2p.spec.js
@@ -191,11 +191,11 @@ describe('libp2p-ipfs-nodejs', () => {
         }
       ], () => {
         pull(
-          pull.values([Buffer('hey')]),
+          pull.values([new Buffer('hey')]),
           conn,
           pull.collect((err, data) => {
             expect(err).to.not.exist
-            expect(data).to.be.eql([Buffer('hey')])
+            expect(data).to.be.eql([new Buffer('hey')])
             done()
           })
         )
@@ -274,11 +274,11 @@ describe('libp2p-ipfs-nodejs', () => {
         }
       ], () => {
         pull(
-          pull.values([Buffer('hey')]),
+          pull.values([new Buffer('hey')]),
           conn,
           pull.collect((err, data) => {
             expect(err).to.not.exist
-            expect(data).to.be.eql([Buffer('hey')])
+            expect(data).to.be.eql([new Buffer('hey')])
             done()
           })
         )
@@ -394,11 +394,11 @@ describe('libp2p-ipfs-nodejs', () => {
       expect(Object.keys(peers)).to.have.length(4)
 
       pull(
-        pull.values([Buffer('hey')]),
+        pull.values([new Buffer('hey')]),
         conn,
         pull.collect((err, data) => {
           expect(err).to.not.exist
-          expect(data).to.be.eql([Buffer('hey')])
+          expect(data).to.be.eql([new Buffer('hey')])
           done()
         })
       )


### PR DESCRIPTION
This is just a recommendation for good practices, using `Buffer.from` and `Buffer.alloc` are preferred over the overloaded `Buffer` or `new Buffer` constructor. This should also resolve the annoying deprecation messages about the `Buffer` constructor.