### PR TITLE
fix: mdns default service tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "libp2p": "^0.3.1",
-    "libp2p-mdns": "^0.5.0",
+    "libp2p-mdns": "^0.5.1",
     "libp2p-secio": "^0.6.4",
     "libp2p-spdy": "^0.10.1",
     "libp2p-swarm": "^0.26.7",

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ class Node extends libp2p {
     }
 
     if (options.mdns) {
-      modules.discovery.push(new MulticastDNS(peerInfo))
+      modules.discovery.push(new MulticastDNS(peerInfo, 'ipfs.local'))
     }
 
     super(modules, peerInfo, peerBook, options)


### PR DESCRIPTION
Depends on https://github.com/libp2p/go-libp2p/issues/176 resolution