### PR TITLE
Replace spdy with multiplex + echo example changes

### DIFF
--- a/examples/echo/dialer.js
+++ b/examples/echo/dialer.js
@@ -34,7 +34,14 @@ async.parallel([
 
   const peerListener = new PeerInfo(ids[1])
   idListener = ids[1]
-  peerListener.multiaddr.add(multiaddr('/ip4/127.0.0.1/tcp/10333'))
+
+  let toDial = '/ip4/127.0.0.1/tcp/10333'
+
+  if (process.argv[2] !== undefined) {
+    toDial = process.argv[2]
+  }
+
+  peerListener.multiaddr.add(multiaddr(toDial))
   nodeDialer.start((err) => {
     if (err) {
       throw err
@@ -55,12 +62,14 @@ async.parallel([
       pull(
         pull.values(['hey']),
         conn,
-        pull.through(console.log),
+        pull.through((data) => {
+          console.log('received data:', data.toString())
+        }),
         pull.collect((err, data) => {
           if (err) {
             throw err
           }
-          console.log('received echo:', data.toString())
+          console.log('stream ended')
         })
       )
     })

--- a/examples/echo/dialer.js
+++ b/examples/echo/dialer.js
@@ -62,14 +62,8 @@ async.parallel([
       pull(
         pull.values(['hey']),
         conn,
-        pull.through((data) => {
-          console.log('received data:', data.toString())
-        }),
-        pull.collect((err, data) => {
-          if (err) {
-            throw err
-          }
-          console.log('stream ended')
+        pull.drain((data) => {
+          console.log('got data: ' + data)
         })
       )
     })

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "libp2p": "^0.3.1",
     "libp2p-mdns": "^0.5.0",
+    "libp2p-multiplex": "^0.3.1",
     "libp2p-secio": "^0.6.4",
     "libp2p-spdy": "^0.10.1",
     "libp2p-swarm": "^0.26.7",

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,9 @@ const TCP = require('libp2p-tcp')
 const WebRTCStar = require('libp2p-webrtc-star')
 const MulticastDNS = require('libp2p-mdns')
 const WS = require('libp2p-websockets')
-const spdy = require('libp2p-spdy')
+// TODO remove if not needed
+// const spdy = require('libp2p-spdy')
+const multiplex = require('libp2p-multiplex')
 const secio = require('libp2p-secio')
 const libp2p = require('libp2p')
 
@@ -22,7 +24,7 @@ class Node extends libp2p {
       ],
       connection: {
         muxer: [
-          spdy
+          multiplex
         ],
         crypto: [
           secio


### PR DESCRIPTION
Replaced spdy with multiplex for testing interop with go-libp2p.

Changed the dialer in the echo example to accept argument for who to dial.

# js and go interop

Test of the interopability between js-libp2p and go-libp2p

## Fixes pending

- Enable multiplex in go-libp2p-swarm
    - https://github.com/libp2p/go-libp2p-swarm/pull/16

## How to test

have projects ipfs/js-libp2p-ipfs-nodejs and libp2p/go-libp2p
cloned locally.

In libp2p/go-libp2p:

```
➜  go-libp2p git:(master) ls
CONTRIBUTE.md Makefile      TODO          p2p           roadmap.md
LICENSE       README.md     examples      package.json
➜  go-libp2p git:(master) cd examples/echo
➜  echo git:(master) ls
README.md main.go
➜  echo git:(master) go run main.go -l 4444
12:08:10.764 WARNI     swarm2: Listener not given PrivateKey, so WILL NOT SECURE conns. swarm_listen.go:83
2017/01/24 12:08:10 I am /ip4/127.0.0.1/tcp/4444/ipfs/QmPbpcZzM2Ac47uA2oebSaDPVbSccGtRFf8rbF4dpNHteN
2017/01/24 12:08:10 listening for connections
```

Copy address from "I am", which in this case is `/ip4/127.0.0.1/tcp/4444/ipfs/QmPbpcZzM2Ac47uA2oebSaDPVbSccGtRFf8rbF4dpNHteN`

In ipfs/js-libp2p-ipfs-nodejs:

```
➜  echo git:(master) ✗ node dialer.js /ip4/127.0.0.1/tcp/4444/ipfs/QmU9jbSMad771NY4YC6fWV9VQxcaB8Q4b6F8WmfXnLSTEe
Dialer ready, listening on:
/ip4/127.0.0.1/tcp/4444/ipfs/QmU9jbSMad771NY4YC6fWV9VQxcaB8Q4b6F8WmfXnLSTEe/ipfs/QmcrQZ6RJdpYuGvZqD5QEHAv6qX4BrQLJLQPQUrTrzdcgm
nodeA dialed to nodeB on protocol: /echo/1.0.0
received data: hey
```

And in the output of libp2p/go-libp2p, you'll see:

```
12:09:37.492 WARNI       conn: listener %s listening INSECURELY! <Listener <peer.ID U9jbSM> /ip4/127.0.0.1/tcp/4444> listen.go:108
2017/01/24 12:09:37 Got a new stream!
2017/01/24 12:09:37 read request: "hey"
```

So everything was working in the interop tests!

## However

This branch fails with two test failures:

```
  1) libp2p-ipfs-nodejs libp2p.hangupByMultiaddr nodeA to nodeB:
     Uncaught AssertionError: expected [ Array(1) ] to have a length of 0 but got 1
      at parallel (test/libp2p.spec.js:267:65)
      at node_modules/async/internal/parallel.js:27:9
      at eachOfArrayLike (node_modules/async/eachOf.js:57:9)
      at exports.default (node_modules/async/eachOf.js:9:5)
      at _parallel (node_modules/async/internal/parallel.js:26:5)
      at parallelLimit (node_modules/async/parallel.js:85:26)
      at Timeout.check [as _onTimeout] (test/libp2p.spec.js:262:9)

  2) libp2p-ipfs-nodejs libp2p.hangupByPeerInfo nodeA to nodeB:
     TypeError: "listener" argument must be a function
      at MultiplexMuxer.end (node_modules/libp2p-multiplex/src/muxer.js:57:20)
      at Swarm.hangUp (node_modules/libp2p-swarm/src/index.js:117:13)
      at Node.hangUpByPeerInfo (node_modules/libp2p/src/index.js:259:16)
at Context.it (test/libp2p.spec.js:340:11)
```