### PR TITLE
feat: add multiplex to default muxers

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "libp2p": "~0.5.4",
     "libp2p-mdns": "~0.6.1",
-    "libp2p-multiplex": "~0.4.0",
+    "libp2p-multiplex": "~0.4.1",
     "libp2p-railing": "~0.4.1",
     "libp2p-secio": "~0.6.7",
     "libp2p-spdy": "~0.10.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/ipfs/js-libp2p-ipfs-nodejs#readme",
   "devDependencies": {
     "aegir": "^10.0.0",
-    "async": "^2.1.4",
+    "async": "^2.1.5",
     "chai": "^3.5.0",
     "pre-commit": "^1.2.2",
     "pull-stream": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "libp2p-railing": "~0.4.1",
     "libp2p-secio": "~0.6.7",
     "libp2p-spdy": "~0.10.4",
-    "libp2p-swarm": "~0.26.17",
+    "libp2p-swarm": "~0.26.18",
     "libp2p-tcp": "~0.9.3",
     "libp2p-webrtc-star": "~0.8.8",
     "libp2p-websockets": "~0.9.2",

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ function getMuxers (options) {
   } else if (options) {
     return mapMuxers(options)
   } else {
-    return [spdy, multiplex]
+    return [multiplex, spdy]
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,18 +11,28 @@ const multiplex = require('libp2p-multiplex')
 const secio = require('libp2p-secio')
 const libp2p = require('libp2p')
 
+function mapMuxers (list) {
+  return list.map((pref) => {
+    if (typeof pref !== 'string') {
+      return pref
+    }
+    switch (pref.trim().toLowerCase()) {
+      case 'spdy':
+        return spdy
+      case 'multiplex':
+        return multiplex
+      default:
+        throw new Error(pref + ' muxer not available')
+    }
+  })
+}
+
 function getMuxers (options) {
   if (process.env.LIBP2P_MUXER) {
     const muxerPrefs = process.env.LIBP2P_MUXER
-    return muxerPrefs.split(',').map((pref) => {
-      switch (pref) {
-      case 'spdy': return spdy
-      case 'multiplex': return multiplex
-      default: throw new Error(pref + ' muxer not available')
-      }
-    })
+    return mapMuxers(muxerPrefs.split(','))
   } else if (options) {
-    return options
+    return mapMuxers(options)
   } else {
     return [spdy, multiplex]
   }
@@ -40,7 +50,7 @@ class Node extends libp2p {
         webRTCStar
       ],
       connection: {
-        muxer: getMuxers(),
+        muxer: getMuxers(options.muxer),
         crypto: [
           secio
         ]

--- a/test/libp2p.spec.js
+++ b/test/libp2p.spec.js
@@ -138,6 +138,21 @@ describe('libp2p-ipfs-nodejs', () => {
     })
   })
 
+  it('create libp2pNode with multiplex only', (done) => {
+    const old = process.env.LIBP2P_MUXER
+    process.env.LIBP2P_MUXER = ''
+    PeerInfo.create((err, info) => {
+      expect(err).to.not.exist
+      const b = new Node(info, null, {muxer: ['multiplex']})
+      expect(b.modules.connection.muxer).to.eql([
+        require('libp2p-multiplex')
+      ])
+
+      process.env.LIBP2P_MUXER = old
+      done()
+    })
+  })
+
   it('mdns discovery', (done) => {
     nodeA.discovery.once('peer', (peerInfo) => {
       expect(nodeB.peerInfo.id.toB58String())

--- a/test/libp2p.spec.js
+++ b/test/libp2p.spec.js
@@ -148,7 +148,9 @@ describe('libp2p-ipfs-nodejs', () => {
         require('libp2p-multiplex')
       ])
 
-      process.env.LIBP2P_MUXER = old
+      if (old) {
+        process.env.LIBP2P_MUXER = old
+      }
       done()
     })
   })


### PR DESCRIPTION
BREAKING CHANGE: Prefer `multiplex` over `spdy`, as it works better with go-ipfs